### PR TITLE
Add song time remaining to Discord RPC

### DIFF
--- a/src/audio/AudioStream.ts
+++ b/src/audio/AudioStream.ts
@@ -228,10 +228,6 @@ class AudioStream {
         }
         global_title = info.title
         global_artist = info.artist
-        axios.post('http://localhost:9000/', 
-          {"artist": info.artist, "title": info.title, "currentTime": this.audio.currentTime, "duration": this.duration},
-          {headers: {'content-type' : 'application/json'}}
-        ).then(response => console.log(response))
         const hlsConfig = { ...HlsConfig, fLoader: creatorFLoader }
         this.hls = new Hls(hlsConfig)
 
@@ -326,7 +322,7 @@ class AudioStream {
     // In case we haven't faded out the last pause, pause again and
     // clear our listener for the end of the pause fade.
     axios.post('http://localhost:9000/', 
-          {"artist": global_artist, "title": global_title, "currentTime": this.audio.currentTime, "duration": this.duration}, 
+          {"artist": global_artist, "title": global_title, "currentTime": this.audio.currentTime, "duration": this.audio.duration}, 
           {headers: {'content-type' : 'application/json'}}
         ).then(response => console.log(response))
     this.audio.removeEventListener('fade-out', this._pauseInternal)
@@ -419,6 +415,10 @@ class AudioStream {
 
   seek = (seconds: number) => {
     this.audio.currentTime = seconds
+    axios.post('http://localhost:9000/', 
+      {"artist": global_artist, "title": global_title, "currentTime": this.audio.currentTime, "duration": this.audio.duration}, 
+      {headers: {'content-type' : 'application/json'}}
+    ).then(response => console.log(response))
   }
 
   setVolume = (value: number) => {

--- a/src/audio/AudioStream.ts
+++ b/src/audio/AudioStream.ts
@@ -229,7 +229,7 @@ class AudioStream {
         global_title = info.title
         global_artist = info.artist
         axios.post('http://localhost:9000/', 
-          {"artist": info.artist, "title": info.title}, 
+          {"artist": info.artist, "title": info.title, "currentTime": this.audio.currentTime, "duration": this.duration},
           {headers: {'content-type' : 'application/json'}}
         ).then(response => console.log(response))
         const hlsConfig = { ...HlsConfig, fLoader: creatorFLoader }
@@ -326,7 +326,7 @@ class AudioStream {
     // In case we haven't faded out the last pause, pause again and
     // clear our listener for the end of the pause fade.
     axios.post('http://localhost:9000/', 
-          {"artist": global_artist, "title": global_title}, 
+          {"artist": global_artist, "title": global_title, "currentTime": this.audio.currentTime, "duration": this.duration}, 
           {headers: {'content-type' : 'application/json'}}
         ).then(response => console.log(response))
     this.audio.removeEventListener('fade-out', this._pauseInternal)

--- a/src/electron.js
+++ b/src/electron.js
@@ -31,18 +31,21 @@ function startRPC() {
     });
 }
 
-function UpdateRPC(artist, title) {
-    rpc.request('SET_ACTIVITY', {
-        pid: process.pid,
-        activity : {
-            details : `Listening to ${title}`,
-            state: `by ${artist}`,
-            assets : {
-                large_image : "audius",
-                large_text : `Plugin By Ashe Muller`
-            }
-        }
-    })
+function UpdateRPC(artist, title, currentTime, duration) {
+  rpc.request('SET_ACTIVITY', {
+      pid: process.pid,
+      activity : {
+          details : `Listening to ${title}`,
+          state: `by ${artist}`,
+          assets : {
+              large_image : "audius",
+              large_text : `Plugin By Ashe Muller`
+          },
+          timestamps: {
+            end: Math.floor(Date.now() / 1000) + (duration - currentTime)
+          }
+      }
+  })
 }
 
 function clearRPC() {
@@ -72,10 +75,10 @@ server.use(
 );
 
 server.post('/', (req, res) => {
-    if (req.body.artist && req.body.title){
-        UpdateRPC(req.body.artist, req.body.title);
-    }
-    res.status(200).send("OK");
+  if (req.body.artist && req.body.title && req.body.currentTime && req.body.duration) {
+      UpdateRPC(req.body.artist, req.body.title, req.body.currentTime, req.body.duration);
+  }
+  res.status(200).send("OK");
 });
 
 server.delete('/', (req, res) => {

--- a/src/electron.js
+++ b/src/electron.js
@@ -75,7 +75,7 @@ server.use(
 );
 
 server.post('/', (req, res) => {
-  if (req.body.artist && req.body.title && req.body.currentTime && req.body.duration) {
+  if (req.body.hasOwnProperty("artist") && req.body.hasOwnProperty("title") && req.body.hasOwnProperty("currentTime") && req.body.hasOwnProperty("duration")) {
       UpdateRPC(req.body.artist, req.body.title, req.body.currentTime, req.body.duration);
   }
   res.status(200).send("OK");


### PR DESCRIPTION
- Included the current time and total song duration from the audio object in AudioStream.ts in the post request to the RPC handler. Displays the time remaining in the song by setting the end timestamp in the RPC update to the current time + the time left in the song.

- Added RPC update POST request to seek function to update the time remaining on seek.

- Removed seemingly unnecessary POST request, noticed it was sending twice on play so removed one of them and it still worked fine.

- Replaced if statement body in server post handler with hasOwnProperty to fix a bug where if currentTime was 0 it evaluated to false.

Screenshot:
![image](https://user-images.githubusercontent.com/8465805/148080183-0b0213df-e97c-4400-acd1-170c59608103.png)
